### PR TITLE
exposed host port variable for multi-container hosts & drain time, fixed ECS role

### DIFF
--- a/alb-service/alb/main.tf
+++ b/alb-service/alb/main.tf
@@ -63,6 +63,10 @@ variable "vpc_id" {
   description = "The id of the VPC."
 }
 
+variable "deregistration_delay" {
+  description = "The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused."
+}
+
 /**
  * Resources.
  */
@@ -80,11 +84,12 @@ resource "aws_alb" "main" {
 }
 
 resource "aws_alb_target_group" "main" {
-  name       = "alb-target-${var.name}"
-  port       = "${var.port}"
-  protocol   = "HTTP"
-  vpc_id     = "${var.vpc_id}"
-  depends_on = ["aws_alb.main"]
+  name                  = "alb-target-${var.name}"
+  port                  = "${var.port}"
+  protocol              = "HTTP"
+  vpc_id                = "${var.vpc_id}"
+  depends_on            = ["aws_alb.main"]
+  deregistration_delay  = "${var.deregistration_delay}"
 
   stickiness {
     type    = "lb_cookie"

--- a/alb-service/main.tf
+++ b/alb-service/main.tf
@@ -43,7 +43,7 @@ variable "security_groups" {
   description = "Comma separated list of security group IDs that will be passed to the ALB module"
 }
 
-variable "port" {
+variable "host_port" {
   description = "The container host port"
 }
 
@@ -98,6 +98,11 @@ variable "health_matcher" {
 variable "health_interval" {
   description = "Healthcheck check frequency"
   default     = "30"
+}
+
+variable "deregistration_delay" {
+  description = "The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused."
+  default     = "300"
 }
 
 variable "container_port" {
@@ -184,7 +189,7 @@ module "task" {
   [
     {
       "containerPort": ${var.container_port},
-      "hostPort": ${var.port}
+      "hostPort": ${var.host_port}
     }
   ]
 EOF
@@ -193,21 +198,22 @@ EOF
 module "alb" {
   source = "./alb"
 
-  name               = "${module.task.name}"
-  port               = "${var.port}"
-  environment        = "${var.environment}"
-  subnet_ids         = "${var.subnet_ids}"
-  external_dns_name  = "${coalesce(var.external_dns_name, module.task.name)}"
-  internal_dns_name  = "${coalesce(var.internal_dns_name, module.task.name)}"
-  health_path        = "${var.health_path}"
-  health_interval    = "${var.health_interval}"
-  health_matcher     = "${var.health_matcher}"
-  external_zone_id   = "${var.external_zone_id}"
-  internal_zone_id   = "${var.internal_zone_id}"
-  security_groups    = "${var.security_groups}"
-  log_bucket         = "${var.log_bucket}"
-  ssl_certificate_id = "${var.ssl_certificate_id}"
-  vpc_id             = "${var.vpc_id}"
+  name                 = "${module.task.name}"
+  port                 = "${var.container_port}"
+  environment          = "${var.environment}"
+  subnet_ids           = "${var.subnet_ids}"
+  external_dns_name    = "${coalesce(var.external_dns_name, module.task.name)}"
+  internal_dns_name    = "${coalesce(var.internal_dns_name, module.task.name)}"
+  health_path          = "${var.health_path}"
+  health_interval      = "${var.health_interval}"
+  health_matcher       = "${var.health_matcher}"
+  deregistration_delay = "${var.deregistration_delay}"
+  external_zone_id     = "${var.external_zone_id}"
+  internal_zone_id     = "${var.internal_zone_id}"
+  security_groups      = "${var.security_groups}"
+  log_bucket           = "${var.log_bucket}"
+  ssl_certificate_id   = "${var.ssl_certificate_id}"
+  vpc_id               = "${var.vpc_id}"
 }
 
 /**

--- a/iam-role/main.tf
+++ b/iam-role/main.tf
@@ -43,7 +43,9 @@ resource "aws_iam_role_policy" "default_ecs_service_role_policy" {
         "ec2:Describe*",
         "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
         "elasticloadbalancing:Describe*",
-        "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
+        "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:DeregisterTargets"
       ],
       "Resource": "*"
     }
@@ -97,7 +99,7 @@ EOF
 resource "aws_iam_instance_profile" "default_ecs" {
   name  = "ecs-instance-profile-${var.name}-${var.environment}"
   path  = "/"
-  roles = ["${aws_iam_role.default_ecs_role.name}"]
+  role  = "${aws_iam_role.default_ecs_role.name}"
 }
 
 output "default_ecs_role_id" {


### PR DESCRIPTION
Multiple containers per host
overview
---
- exposed "host port" variable to enable dynamic port mapping on ECS
- updated ECS IAM role to allow it to automagically register/unregister tasks with ALB target group
- removed deprecated 'roles' declaration