### PR TITLE
Allowing Alb to be an internal service

### DIFF
--- a/alb-service/alb/main.tf
+++ b/alb-service/alb/main.tf
@@ -67,6 +67,10 @@ variable "deregistration_delay" {
   description = "The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused."
 }
 
+variable "internal" {
+  description = "Make this an internal load balancer"
+}
+
 /**
  * Resources.
  */
@@ -74,7 +78,7 @@ variable "deregistration_delay" {
 # Create a new load balancer
 resource "aws_alb" "main" {
   name            = "${var.name}"
-  internal        = false
+  internal        = "${var.internal}"
   subnets         = ["${split(",",var.subnet_ids)}"]
   security_groups = ["${split(",",var.security_groups)}"]
 

--- a/alb-service/alb/main.tf
+++ b/alb-service/alb/main.tf
@@ -69,6 +69,7 @@ variable "deregistration_delay" {
 
 variable "internal" {
   description = "Make this an internal load balancer"
+  default = false
 }
 
 /**

--- a/alb-service/main.tf
+++ b/alb-service/main.tf
@@ -150,7 +150,7 @@ variable "internal" {
   default = false
 }
 
-variable vpc_id {
+variable "vpc_id" {
   description = "The id of the VPC."
 }
 

--- a/alb-service/main.tf
+++ b/alb-service/main.tf
@@ -145,6 +145,11 @@ variable "deployment_maximum_percent" {
   default     = 200
 }
 
+variable "internal" {
+  description = "Make this an internal load balancer"
+  default = false
+}
+
 variable vpc_id {
   description = "The id of the VPC."
 }
@@ -214,6 +219,7 @@ module "alb" {
   log_bucket           = "${var.log_bucket}"
   ssl_certificate_id   = "${var.ssl_certificate_id}"
   vpc_id               = "${var.vpc_id}"
+  internal             = "${var.internal}"
 }
 
 /**

--- a/alb-service/main.tf
+++ b/alb-service/main.tf
@@ -43,7 +43,7 @@ variable "security_groups" {
   description = "Comma separated list of security group IDs that will be passed to the ALB module"
 }
 
-variable "host_port" {
+variable "port" {
   description = "The container host port"
 }
 
@@ -189,7 +189,7 @@ module "task" {
   [
     {
       "containerPort": ${var.container_port},
-      "hostPort": ${var.host_port}
+      "hostPort": ${var.port}
     }
   ]
 EOF


### PR DESCRIPTION
Overview
---
Switch value of internal for alb to variable to be able to choose an internal load balancer.
internal variable defaults to false
- [x] provide the internal variable to alb and internal service 

Additionally
---
Switching alb from host_port back to port from consistency and eliminate confusion.