### PR TITLE
Add dependency on ALB Listeners

### DIFF
--- a/alb-service/alb/main.tf
+++ b/alb-service/alb/main.tf
@@ -113,6 +113,7 @@ resource "aws_alb_listener" "service_https" {
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2015-05"
   certificate_arn   = "${var.ssl_certificate_id}"
+  depends_on        = ["aws_alb_target_group.main"]
 
   default_action {
     target_group_arn = "${aws_alb_target_group.main.arn}"
@@ -124,6 +125,7 @@ resource "aws_alb_listener" "service_http" {
   load_balancer_arn = "${aws_alb.main.arn}"
   port              = "80"
   protocol          = "HTTP"
+  depends_on        = ["aws_alb_target_group.main"]
 
   default_action {
     target_group_arn = "${aws_alb_target_group.main.arn}"

--- a/our_iam/main.tf
+++ b/our_iam/main.tf
@@ -1,84 +1,85 @@
 variable account_id {}
 variable metadata {}
-resource "aws_iam_policy" "billing" {
-  arn = "arn:aws:iam::aws:policy/job-function/Billing"
-}
 
-resource "aws_iam_policy" "cloudwatch_full" {
-  arn = "arn:aws:iam::aws:policy/CloudWatchFullAccess"
-}
+# resource "aws_iam_policy" "billing" {
+#   arn = "arn:aws:iam::aws:policy/job-function/Billing"
+# }
 
-resource "aws_iam_policy" "cloudwatch_read" {
-  arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
-}
+# resource "aws_iam_policy" "cloudwatch_full" {
+#   arn = "arn:aws:iam::aws:policy/CloudWatchFullAccess"
+# }
 
-resource "aws_iam_policy" "ec2_read" {
-  arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
-}
+# resource "aws_iam_policy" "cloudwatch_read" {
+#   arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
+# }
 
-resource "aws_iam_policy" "ec2_full" {
-  arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
-}
+# resource "aws_iam_policy" "ec2_read" {
+#   arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+# }
 
-resource "aws_iam_policy" "ec2_container_service_read" {
-  arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-}
+# resource "aws_iam_policy" "ec2_full" {
+#   arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
+# }
 
-resource "aws_iam_policy" "ec2_container_service_full" {
-  arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
-}
+# resource "aws_iam_policy" "ec2_container_service_read" {
+#   arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+# }
 
-resource "aws_iam_policy" "vpc_read" {
-  arn = "arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess"
-}
+# resource "aws_iam_policy" "ec2_container_service_full" {
+#   arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
+# }
 
-resource "aws_iam_policy" "kinesis_read" {
-  arn = "arn:aws:iam::aws:policy/AmazonKinesisReadOnlyAccess"
-}
+# resource "aws_iam_policy" "vpc_read" {
+#   arn = "arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess"
+# }
 
-resource "aws_iam_policy" "kinesis_full" {
-  arn = "arn:aws:iam::aws:policy/AmazonKinesisFullAccess"
-}
+# resource "aws_iam_policy" "kinesis_read" {
+#   arn = "arn:aws:iam::aws:policy/AmazonKinesisReadOnlyAccess"
+# }
 
-resource "aws_iam_policy" "elasticache_read" {
-  arn = "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
-}
+# resource "aws_iam_policy" "kinesis_full" {
+#   arn = "arn:aws:iam::aws:policy/AmazonKinesisFullAccess"
+# }
 
-resource "aws_iam_policy" "elasticache_full" {
-  arn = "arn:aws:iam::aws:policy/AmazonElastiCacheFullAccess"
-}
+# resource "aws_iam_policy" "elasticache_read" {
+#   arn = "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+# }
 
-resource "aws_iam_policy" "s3_read" {
-  arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
-}
+# resource "aws_iam_policy" "elasticache_full" {
+#   arn = "arn:aws:iam::aws:policy/AmazonElastiCacheFullAccess"
+# }
 
-resource "aws_iam_policy" "s3_full" {
-  arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
-}
+# resource "aws_iam_policy" "s3_read" {
+#   arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+# }
 
-resource "aws_iam_policy" "cloudtrail_read" {
-  arn = "arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess"
-}
+# resource "aws_iam_policy" "s3_full" {
+#   arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+# }
 
-resource "aws_iam_policy" "rds_read" {
-  arn = "arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess"
-}
+# resource "aws_iam_policy" "cloudtrail_read" {
+#   arn = "arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess"
+# }
 
-resource "aws_iam_policy" "lambda_read" {
-  arn = "arn:aws:iam::aws:policy/AWSLambdaReadOnlyAccess"
-}
+# resource "aws_iam_policy" "rds_read" {
+#   arn = "arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess"
+# }
 
-resource "aws_iam_policy" "lambda_full" {
-  arn = "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
-}
+# resource "aws_iam_policy" "lambda_read" {
+#   arn = "arn:aws:iam::aws:policy/AWSLambdaReadOnlyAccess"
+# }
 
-resource "aws_iam_policy" "macie_full" {
-  arn = "arn:aws:iam::aws:policy/AmazonMacieFullAccess"
-}
+# resource "aws_iam_policy" "lambda_full" {
+#   arn = "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+# }
 
-resource "aws_iam_policy" "iam_read" {
-  arn = "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
-}
+# resource "aws_iam_policy" "macie_full" {
+#   arn = "arn:aws:iam::aws:policy/AmazonMacieFullAccess"
+# }
+
+# resource "aws_iam_policy" "iam_read" {
+#   arn = "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
+# }
 
 resource "aws_iam_saml_provider" "okta" {
   name                   = "Okta"

--- a/our_iam/main.tf
+++ b/our_iam/main.tf
@@ -1,3 +1,5 @@
+variable account_id {}
+variable metadata {}
 resource "aws_iam_policy" "billing" {
   arn = "arn:aws:iam::aws:policy/job-function/Billing"
 }
@@ -94,7 +96,7 @@ resource "aws_iam_role" "billing-okta-sso-role" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
+        "Federated": "arn:aws:iam::${var.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
       },
       "Action": "sts:AssumeRoleWithSAML",
       "Condition": {
@@ -124,7 +126,7 @@ resource "aws_iam_role" "admin-okta-sso-role" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
+        "Federated": "arn:aws:iam::${var.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
       },
       "Action": "sts:AssumeRoleWithSAML",
       "Condition": {
@@ -154,7 +156,7 @@ resource "aws_iam_role" "audit-okta-sso-role" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
+        "Federated": "arn:aws:iam::${var.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
       },
       "Action": "sts:AssumeRoleWithSAML",
       "Condition": {
@@ -214,7 +216,7 @@ resource "aws_iam_role" "cloudwatch-okta-sso-role" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
+        "Federated": "arn:aws:iam::${var.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
       },
       "Action": "sts:AssumeRoleWithSAML",
       "Condition": {
@@ -244,7 +246,7 @@ resource "aws_iam_role" "developer-okta-sso-role" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
+        "Federated": "arn:aws:iam::${var.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
       },
       "Action": "sts:AssumeRoleWithSAML",
       "Condition": {
@@ -314,7 +316,7 @@ resource "aws_iam_role" "deployer-okta-sso-role" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
+        "Federated": "arn:aws:iam::${var.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
       },
       "Action": "sts:AssumeRoleWithSAML",
       "Condition": {

--- a/our_iam/main.tf
+++ b/our_iam/main.tf
@@ -1,0 +1,349 @@
+resource "aws_iam_policy" "billing" {
+  arn = "arn:aws:iam::aws:policy/job-function/Billing"
+}
+
+resource "aws_iam_policy" "cloudwatch_full" {
+  arn = "arn:aws:iam::aws:policy/CloudWatchFullAccess"
+}
+
+resource "aws_iam_policy" "cloudwatch_read" {
+  arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
+}
+
+resource "aws_iam_policy" "ec2_read" {
+  arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+}
+
+resource "aws_iam_policy" "ec2_full" {
+  arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
+}
+
+resource "aws_iam_policy" "ec2_container_service_read" {
+  arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_policy" "ec2_container_service_full" {
+  arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
+}
+
+resource "aws_iam_policy" "vpc_read" {
+  arn = "arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess"
+}
+
+resource "aws_iam_policy" "kinesis_read" {
+  arn = "arn:aws:iam::aws:policy/AmazonKinesisReadOnlyAccess"
+}
+
+resource "aws_iam_policy" "kinesis_full" {
+  arn = "arn:aws:iam::aws:policy/AmazonKinesisFullAccess"
+}
+
+resource "aws_iam_policy" "elasticache_read" {
+  arn = "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+}
+
+resource "aws_iam_policy" "elasticache_full" {
+  arn = "arn:aws:iam::aws:policy/AmazonElastiCacheFullAccess"
+}
+
+resource "aws_iam_policy" "s3_read" {
+  arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+}
+
+resource "aws_iam_policy" "s3_full" {
+  arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+
+resource "aws_iam_policy" "cloudtrail_read" {
+  arn = "arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess"
+}
+
+resource "aws_iam_policy" "rds_read" {
+  arn = "arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess"
+}
+
+resource "aws_iam_policy" "lambda_read" {
+  arn = "arn:aws:iam::aws:policy/AWSLambdaReadOnlyAccess"
+}
+
+resource "aws_iam_policy" "lambda_full" {
+  arn = "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+}
+
+resource "aws_iam_policy" "macie_full" {
+  arn = "arn:aws:iam::aws:policy/AmazonMacieFullAccess"
+}
+
+resource "aws_iam_policy" "iam_read" {
+  arn = "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
+}
+
+resource "aws_iam_saml_provider" "okta" {
+  name                   = "Okta"
+  saml_metadata_document = "${file("../../metadata.xml")}"
+}
+
+resource "aws_iam_role" "billing-okta-sso-role" {
+  name        = "billing-okta-sso-role"
+  description = "Role that allows billing management without touching other infra."
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
+      },
+      "Action": "sts:AssumeRoleWithSAML",
+      "Condition": {
+        "StringEquals": {
+          "SAML:aud": "https://signin.aws.amazon.com/saml"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "billing-billingOktaSSO-attach" {
+  role       = "${aws_iam_role.billing-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/job-function/Billing"
+}
+
+resource "aws_iam_role" "admin-okta-sso-role" {
+  name        = "admin-okta-sso-role"
+  description = "Allows full admin access to the infrastructure for a few select employees."
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
+      },
+      "Action": "sts:AssumeRoleWithSAML",
+      "Condition": {
+        "StringEquals": {
+          "SAML:aud": "https://signin.aws.amazon.com/saml"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "admin-adminOktaSSO-attach" {
+  role       = "${aws_iam_role.admin-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "aws_iam_role" "audit-okta-sso-role" {
+  name        = "audit-okta-sso-role"
+  description = "Allows read only access to resources that are important for auditing"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
+      },
+      "Action": "sts:AssumeRoleWithSAML",
+      "Condition": {
+        "StringEquals": {
+          "SAML:aud": "https://signin.aws.amazon.com/saml"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "audit-auditOktaSSO-ec2-attach" {
+  role       = "${aws_iam_role.audit-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "audit-auditOktaSSO-s3-attach" {
+  role       = "${aws_iam_role.audit-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "audit-auditOktaSSO-cloudtrail-attach" {
+  role       = "${aws_iam_role.audit-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "audit-auditOktaSSO-macie-attach" {
+  role       = "${aws_iam_role.audit-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonMacieFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "audit-auditOktaSSO-iam-attach" {
+  role       = "${aws_iam_role.audit-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "audit-auditOktaSSO-rds-attach" {
+  role       = "${aws_iam_role.audit-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "audit-auditOktaSSO-cloudwatch-attach" {
+  role       = "${aws_iam_role.audit-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
+}
+
+resource "aws_iam_role" "cloudwatch-okta-sso-role" {
+  name        = "cloudwatch-okta-sso-role"
+  description = "Full Access to cloudwatch intended for developers"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
+      },
+      "Action": "sts:AssumeRoleWithSAML",
+      "Condition": {
+        "StringEquals": {
+          "SAML:aud": "https://signin.aws.amazon.com/saml"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch-cloudwatchOktaSSO-attach" {
+  role       = "${aws_iam_role.cloudwatch-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchFullAccess"
+}
+
+resource "aws_iam_role" "developer-okta-sso-role" {
+  name        = "developer-okta-sso-role"
+  description = "Full READ Access to most aws resources for debugging and planning purposes"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
+      },
+      "Action": "sts:AssumeRoleWithSAML",
+      "Condition": {
+        "StringEquals": {
+          "SAML:aud": "https://signin.aws.amazon.com/saml"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "developer-developerOktaSSO-ec2repository-attach" {
+  role       = "${aws_iam_role.developer-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "developer-developerOktaSSO-ec2-attach" {
+  role       = "${aws_iam_role.developer-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "developer-developerOktaSSO-vpc-attach" {
+  role       = "${aws_iam_role.developer-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "developer-developerOktaSSO-kinesis-attach" {
+  role       = "${aws_iam_role.developer-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonKinesisReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "developer-developerOktaSSO-elasticache-attach" {
+  role       = "${aws_iam_role.developer-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "developer-developerOktaSSO-s3-attach" {
+  role       = "${aws_iam_role.developer-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "developer-developerOktaSSO-rds-attach" {
+  role       = "${aws_iam_role.developer-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "developer-developerOktaSSO-lambda-attach" {
+  role       = "${aws_iam_role.developer-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AWSLambdaReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "developer-developerOktaSSO-cloudwatch-attach" {
+  role       = "${aws_iam_role.developer-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
+}
+
+resource "aws_iam_role" "deployer-okta-sso-role" {
+  name        = "deployer-okta-sso-role"
+  description = "Allows for ecs updates and access to common troubleshooting places"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:saml-provider/${aws_iam_saml_provider.okta.name}"
+      },
+      "Action": "sts:AssumeRoleWithSAML",
+      "Condition": {
+        "StringEquals": {
+          "SAML:aud": "https://signin.aws.amazon.com/saml"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "deployer-deployerOktaSSO-ec2container-attach" {
+  role       = "${aws_iam_role.deployer-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "deployer-deployerOktaSSO-ec2-attach" {
+  role       = "${aws_iam_role.deployer-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "deployer-deployerOktaSSO-cloudwatch-attach" {
+  role       = "${aws_iam_role.deployer-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "deployer-deployerOktaSSO-deployment-attach" {
+  role       = "${aws_iam_role.deployer-okta-sso-role.name}"
+  policy_arn = "arn:aws:iam::648518523462:policy/deployment"
+}

--- a/our_iam/main.tf
+++ b/our_iam/main.tf
@@ -82,7 +82,7 @@ resource "aws_iam_policy" "iam_read" {
 
 resource "aws_iam_saml_provider" "okta" {
   name                   = "Okta"
-  saml_metadata_document = "${file("../../metadata.xml")}"
+  saml_metadata_document = "${var.metadata}"
 }
 
 resource "aws_iam_role" "billing-okta-sso-role" {

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -167,7 +167,6 @@ resource "aws_db_instance" "main" {
   vpc_security_group_ids = ["${aws_security_group.main.id}"]
   publicly_accessible    = "${var.publicly_accessible}"
   storage_encrypted      = true
-  kms_key_id             = "${var.kms_key_id}"
 }
 
 output "addr" {

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -134,6 +134,11 @@ resource "aws_db_subnet_group" "main" {
   subnet_ids  = ["${var.subnet_ids}"]
 }
 
+resource "aws_kms_key" "postgres" {
+  description             = "Postgres encryption key"
+  deletion_window_in_days = 30
+}
+
 resource "aws_db_instance" "main" {
   identifier = "${var.name}"
 
@@ -161,6 +166,7 @@ resource "aws_db_instance" "main" {
   db_subnet_group_name   = "${aws_db_subnet_group.main.id}"
   vpc_security_group_ids = ["${aws_security_group.main.id}"]
   publicly_accessible    = "${var.publicly_accessible}"
+  kms_key_id             = "${aws_kms_key.postgres.arn}"
 }
 
 output "addr" {

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -134,7 +134,7 @@ resource "aws_db_subnet_group" "main" {
   subnet_ids  = ["${var.subnet_ids}"]
 }
 
-resource "aws_kms_key" "postgres" {
+resource "aws_kms_key" "postgres-finn-demo-stg" {
   description             = "Postgres encryption key"
   deletion_window_in_days = 30
 }
@@ -167,7 +167,7 @@ resource "aws_db_instance" "main" {
   vpc_security_group_ids = ["${aws_security_group.main.id}"]
   publicly_accessible    = "${var.publicly_accessible}"
   storage_encrypted      = true
-  kms_key_id             = "${aws_kms_key.postgres.arn}"
+  kms_key_id             = "${aws_kms_key.postgres-finn-demo-stg.arn}"
 }
 
 output "addr" {

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -97,10 +97,10 @@ variable "subnet_ids" {
   type        = "list"
 }
 
-variable "kms_key_id" {
-  description = "The key that is used for postgres encryption"
-  type        = "string"
-}
+# variable "kms_key_id" {
+#   description = "The key that is used for postgres encryption"
+#   type        = "string"
+# }
 
 resource "aws_security_group" "main" {
   name        = "${var.name}-rds"
@@ -172,7 +172,7 @@ resource "aws_db_instance" "main" {
   vpc_security_group_ids = ["${aws_security_group.main.id}"]
   publicly_accessible    = "${var.publicly_accessible}"
   storage_encrypted      = true
-  kms_key_id             = "${var.kms_key_id}"
+  kms_key_id             = "${aws_kms_key.postgres.arn}"
 }
 
 output "addr" {

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -97,6 +97,12 @@ variable "subnet_ids" {
   type        = "list"
 }
 
+variable "kms_key_id" {
+  description = "The key that is used for postgres encryption"
+  type        = "string"
+  default     = "${aws_kms_key.postgres.arn}"
+}
+
 resource "aws_security_group" "main" {
   name        = "${var.name}-rds"
   description = "Allows traffic to RDS from other security groups"
@@ -134,7 +140,7 @@ resource "aws_db_subnet_group" "main" {
   subnet_ids  = ["${var.subnet_ids}"]
 }
 
-resource "aws_kms_key" "postgres-finn-demo-stg" {
+resource "aws_kms_key" "postgres" {
   description             = "Postgres encryption key"
   deletion_window_in_days = 30
 }
@@ -167,7 +173,7 @@ resource "aws_db_instance" "main" {
   vpc_security_group_ids = ["${aws_security_group.main.id}"]
   publicly_accessible    = "${var.publicly_accessible}"
   storage_encrypted      = true
-  kms_key_id             = "${aws_kms_key.postgres-finn-demo-stg.arn}"
+  kms_key_id             = "${var.kms_key_id}"
 }
 
 output "addr" {

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -97,10 +97,10 @@ variable "subnet_ids" {
   type        = "list"
 }
 
-# variable "kms_key_id" {
-#   description = "The key that is used for postgres encryption"
-#   type        = "string"
-# }
+variable "kms_key_id" {
+  description = "The key that is used for postgres encryption"
+  type        = "string"
+}
 
 resource "aws_security_group" "main" {
   name        = "${var.name}-rds"
@@ -139,11 +139,6 @@ resource "aws_db_subnet_group" "main" {
   subnet_ids  = ["${var.subnet_ids}"]
 }
 
-resource "aws_kms_key" "postgres" {
-  description             = "Postgres encryption key"
-  deletion_window_in_days = 30
-}
-
 resource "aws_db_instance" "main" {
   identifier = "${var.name}"
 
@@ -172,7 +167,7 @@ resource "aws_db_instance" "main" {
   vpc_security_group_ids = ["${aws_security_group.main.id}"]
   publicly_accessible    = "${var.publicly_accessible}"
   storage_encrypted      = true
-  kms_key_id             = "${aws_kms_key.postgres.arn}"
+  kms_key_id             = "${var.kms_key_id}"
 }
 
 output "addr" {

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -166,6 +166,7 @@ resource "aws_db_instance" "main" {
   db_subnet_group_name   = "${aws_db_subnet_group.main.id}"
   vpc_security_group_ids = ["${aws_security_group.main.id}"]
   publicly_accessible    = "${var.publicly_accessible}"
+  storage_encrypted      = true
   kms_key_id             = "${aws_kms_key.postgres.arn}"
 }
 

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -100,7 +100,6 @@ variable "subnet_ids" {
 variable "kms_key_id" {
   description = "The key that is used for postgres encryption"
   type        = "string"
-  default     = "${aws_kms_key.postgres.arn}"
 }
 
 resource "aws_security_group" "main" {


### PR DESCRIPTION
Without the dependency there were sometimes errors when trying to plan services. This makes sure that doesn't happen.